### PR TITLE
Added support for apollo-link-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ export default () => {
 };
 ```
 
-You can optionnaly pass extra options:
+You can optionally pass extra options:
 
 - `schemaOptions` (passes options to `makeExecutableSchema`) [link](https://www.apollographql.com/docs/apollo-server/v2/api/graphql-tools.html#makeExecutableSchema)
 - `mockOptions` (passes options to `addMockFunctionsToSchema`) [link](https://www.apollographql.com/docs/apollo-server/v2/api/graphql-tools.html#addMockFunctionsToSchema)
+- `clientResolvers` (passes resolvers to `apollo-link-state`) [link](https://www.apollographql.com/docs/link/links/state.html#resolver)
+- `clientDefaults` (passes defaults to `apollo-link-state`) [link](https://www.apollographql.com/docs/link/links/state.html#default)
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   "dependencies": {
     "apollo-cache-inmemory": "^1.2.1",
     "apollo-client": "^2.3.1",
+    "apollo-link": "^1.2.2",
     "apollo-link-schema": "^1.1.0",
+    "apollo-link-state": "^0.4.1",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.9.2",
     "graphql-tools": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,6 +447,13 @@ apollo-link-schema@^1.1.0:
   dependencies:
     apollo-link "^1.2.2"
 
+apollo-link-state@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/apollo-link-state/-/apollo-link-state-0.4.1.tgz#65e9e0e12c67936b8c4b12b8438434f393104579"
+  dependencies:
+    apollo-utilities "^1.0.8"
+    graphql-anywhere "^4.1.0-alpha.0"
+
 apollo-link@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.1.tgz#c120b16059f9bd93401b9f72b94d2f80f3f305d2"
@@ -466,6 +473,12 @@ apollo-link@^1.0.0, apollo-link@^1.2.2:
 apollo-utilities@^1.0.0, apollo-utilities@^1.0.1, apollo-utilities@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.12.tgz#9e2b2a34cf89f3bf0d73a664effd8c1bb5d1b7f7"
+
+apollo-utilities@^1.0.20, apollo-utilities@^1.0.8:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.20.tgz#b14318686cb67838279fb5f009cca0ec97a4d140"
+  dependencies:
+    fast-json-stable-stringify "^2.0.0"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -3701,6 +3714,12 @@ globby@^5.0.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graphql-anywhere@^4.1.0-alpha.0:
+  version "4.1.18"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.18.tgz#29bfc5d42bf8ee1f5cdc9a9857c98c3eb4b7fab4"
+  dependencies:
+    apollo-utilities "^1.0.20"
 
 graphql-anywhere@^4.1.10:
   version "4.1.10"


### PR DESCRIPTION
This PR adds an `apollo-link-state` dependency and modifies the signature of the default export to accept optional `clientResolvers` and `clientDefaults` to be passed to the state link.